### PR TITLE
chore: cleanup new chrome-aws-lambda interface [sc-7434]

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,10 +2,10 @@ const playwright = require('playwright-core')
 const chromium = require('./build')
 
 async function runTest(args) {
-  const { config, chromium: chrome } = await chromium.prepare(`/tmp/random`)
+  const { fontConfigPath, ldLibraryPath, chromiumPath } = await chromium.prepare(`/tmp/random`)
 
-  const FONTCONFIG_PATH = config.fontConfigPath
-  const LD_LIBRARY_PATH = [...new Set([config.ldLibraryPath, ...process.env.LD_LIBRARY_PATH.split(':')])].join(':')
+  const FONTCONFIG_PATH = fontConfigPath
+  const LD_LIBRARY_PATH = [...new Set([ldLibraryPath, ...process.env.LD_LIBRARY_PATH.split(':')])].join(':')
 
   const options = {
     headless: true, // Always true
@@ -14,7 +14,7 @@ async function runTest(args) {
       FONTCONFIG_PATH
     },
     args,
-    executablePath: chrome.path,
+    executablePath: chromiumPath,
     logger: {      
         isEnabled: (name, severity) => true,
         log: (name, severity, message, args) => console.log(`${name} ${message}`)    

--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ async function runTest(args) {
   const { config, chromium: chrome } = await chromium.prepare(`/tmp/random`)
 
   const FONTCONFIG_PATH = config.fontConfigPath
-  const LD_LIBRARY_PATH = [...new Set([config.awsLibrarPath, ...process.env.LD_LIBRARY_PATH.split(':')])].join(':')
+  const LD_LIBRARY_PATH = [...new Set([config.ldLibraryPath, ...process.env.LD_LIBRARY_PATH.split(':')])].join(':')
 
   const options = {
     headless: true, // Always true

--- a/source/index.ts
+++ b/source/index.ts
@@ -83,13 +83,9 @@ class Chromium {
       await fs.writeFile(join(awsFolder, 'fonts.conf'), fontConfig(awsFolder), { encoding: 'utf8', mode: 0o700})
     }
     return {
-      config: {
-        fontConfigPath: join(folder, 'aws'),
-        ldLibraryPath: join(folder, 'aws', 'lib'),
-      },
-      chromium: {
-        path: chromiumExpectedPath
-      }
+      fontConfigPath: join(folder, 'aws'),
+      ldLibraryPath: join(folder, 'aws', 'lib'),
+      chromiumPath: chromiumExpectedPath,
     }
   }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -85,7 +85,7 @@ class Chromium {
     return {
       config: {
         fontConfigPath: join(folder, 'aws'),
-        awsLibrarPath: join(folder, 'aws', 'lib'),
+        ldLibraryPath: join(folder, 'aws', 'lib'),
       },
       chromium: {
         path: chromiumExpectedPath


### PR DESCRIPTION
We recently changed the interface of chrome-aws-lambda. For SC-7434, I'll then go and update all of checkly-lambda-runners to use the new interface. Before doing so, though, I'd like to merge this PR which does some small cleanup:

* Fix a typo. `awsLibrarPath` -> `ldLibraryPath`.
    * librar seems to be a typo.
    * This code will also be used in the Checkly Agent, not just AWS Lambda. We don't need to have "aws" in the name.
    * I think `ldLibraryPath` makes sense since this will be used as the `LD_LIBRARY_PATH` environment variable. Simply `libraryPath` could also work, though.
*  Simplify the return value.
    * I don't think we need so much nesting if we're only returning three values.
